### PR TITLE
Add disqus-data-identifier so Disqus can find the correct comment thread

### DIFF
--- a/pelican-mockingbird/templates/article_stub.html
+++ b/pelican-mockingbird/templates/article_stub.html
@@ -16,7 +16,7 @@
 
                     <div class="clear"></div>
                     <div class="info">
-                        {% if DISQUS_SITENAME %}<a href="{{ SITEURL }}/{{ article.url }}#disqus_thread" style="text-decoration:underline; color: black">Discuss this post</a> | {% endif %}
+                        {% if DISQUS_SITENAME %}<a href="{{ SITEURL }}/{{ article.url }}#disqus_thread" data-disqus-identifier="{{article.url}}" style="text-decoration:underline; color: black">Discuss this post</a> | {% endif %}
                         {% if article.pinned -%}
                         <a href="{{ SITEURL }}/{{ article.url }}">Posted {{ article.date.strftime("%B %e, %l:%M %P") }}</a>
                         {%- else -%}


### PR DESCRIPTION
For real this time.
