### PR TITLE
Revert "comment count is displayed incorrectly, reverting"

### DIFF
--- a/pelican-mockingbird/templates/base.html
+++ b/pelican-mockingbird/templates/base.html
@@ -73,16 +73,15 @@
 </script>
 <script type="text/javascript">
 /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-/* * * COMMENTING OUT DISQUS CODE BELOW - NEEDS TO BE DEBUGGED * * */
-/* * * var disqus_shortname = 'opensciencecollaboration'; // required: replace example with your forum shortname
+var disqus_shortname = 'opensciencecollaboration'; // required: replace example with your forum shortname
 
+/* * * DON'T EDIT BELOW THIS LINE * * */
 (function () {
 var s = document.createElement('script'); s.async = true;
 s.type = 'text/javascript';
 s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
 (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
-}()); 
-* * */
+}());
 </script>
 
 


### PR DESCRIPTION
This reverts commit 091416f33253b6234f32e48073544ee5e6c3e4ff.

A previous commit commented out the count.js call.  Uncommenting/enabling is now reasonable because I've added data-disqus-identifier which lets disqus tell which thread to get data on.
